### PR TITLE
bluetooth battery statistics fix

### DIFF
--- a/overlay/frameworks/base/core/res/res/xml/power_profile.xml
+++ b/overlay/frameworks/base/core/res/res/xml/power_profile.xml
@@ -22,7 +22,7 @@
     <item name="screen.on">100</item>
     <item name="bluetooth.active">142</item>
     <item name="bluetooth.on">1</item>
-    <item name="bluetooth.at">35690</item>
+    <item name="bluetooth.at">35.69</item>
     <item name="screen.full">240</item>
     <item name="wifi.on">6</item>
     <item name="wifi.active">120</item>


### PR DESCRIPTION
the bluetooth battery statistics shows 1000 times higher usage than the actual usage
